### PR TITLE
oho_profile in Devshop

### DIFF
--- a/web/profiles/oho_profile/oho_profile.install
+++ b/web/profiles/oho_profile/oho_profile.install
@@ -16,6 +16,7 @@ use Drupal\shortcut\Entity\Shortcut;
  *
  * @see system_install()
  */
+ /*
 function oho_profile_install() {
   // Set front page to "node".
   \Drupal::configFactory()->getEditable('system.site')->set('page.front', '/node')->save(TRUE);
@@ -67,3 +68,4 @@ function oho_profile_install() {
     ->set('use_admin_theme', TRUE)
     ->save(TRUE);
 }
+*/


### PR DESCRIPTION
Profile is failing to install in Devshop.  Commenting out install function.
@jonpugh thinks it has something to do with config loading before its ready.